### PR TITLE
Allow successful build despite node warnings

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,8 +3,8 @@
 		{
 			'target_name': 'mkfifo',
 			'sources': ['src/mkfifo.cpp'],
-			'include_dirs': ["<!@(node -p \"require('node-addon-api').include\")"],
-			'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
+			'include_dirs': ["<!@(node --no-warnings -p \"require('node-addon-api').include\")"],
+			'dependencies': ["<!(node --no-warnings -p \"require('node-addon-api').gyp\")"],
 			'conditions': [
 				['OS=="mac"', {
 					'cflags+': ['-fvisibility=hidden'],


### PR DESCRIPTION
I have a project that uses this module and also has a .npmrc file at the project root with `node-options="--experimental-modules"`. With this configuration, the build fails because the gyp node commands load this .npmrc file, which causes node to print out a `ExperimentalWarning` on stderr. Apparently node-gyp automatically fails if anything is printed on stderr, even though the command exits with status 0:

```
> mkfifo@2.0.0 install /Users/tino/Dev/github/resolve-mjs/node_modules/mkfifo
> node-gyp rebuild

(node:51381) ExperimentalWarning: The ESM module loader is experimental.
(node:51481) ExperimentalWarning: The ESM module loader is experimental.
gyp: Call to 'node -p "require('node-addon-api').include"' returned exit status 0 while in binding.gyp. while trying to load binding.gyp
gyp ERR! configure error
gyp ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onCpExit (/Users/tino/.nvm/versions/node/v12.3.1/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:345:16)
gyp ERR! stack     at ChildProcess.emit (events.js:200:13)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:272:12)
gyp ERR! System Darwin 18.5.0
gyp ERR! command "/Users/tino/.nvm/versions/node/v12.3.1/bin/node" "/Users/tino/.nvm/versions/node/v12.3.1/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/tino/Dev/github/resolve-mjs/node_modules/mkfifo
gyp ERR! node -v v12.3.1
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! mkfifo@2.0.0 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the mkfifo@2.0.0 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

Adding --no-warnings to the node commands prevents this otherwise benign warning from breaking install. I know it's not great practice to suppress warnings, but I can't think of a case where failing the build on a warning message without an actual associated error would be desirable.